### PR TITLE
Packet data fix + other

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ const jand = require('jand-ipc')
 async function run() {
     await jand.connect()
     console.log(await jand.getDaemonStatus())
-    console.log(await jand.getProcessList())
     console.log(await jand.getRuntimeProcessList())
     await jand.newProcess({
         Name: 'sus',
@@ -25,7 +24,7 @@ run()
 ```
 
 # Error handling
-If Jand sends back an error a `JandIpcError` will be thrown. 
+If JanD sends back an error a `JandIpcError` will be thrown.
 
 # The entire API Documentation
 > See https://jand.jan0660.dev/advanced/ipc-api for descriptions, unless otherwise specified here.
@@ -34,8 +33,6 @@ If Jand sends back an error a `JandIpcError` will be thrown.
 <dt><a href="#connect">connect()</a></dt>
 <dd><p>Connect to the JanD IPC socket</p>
 </dd>
-<dt><a href="#getProcessList">getProcessList()</a> ⇒ <code>Promise.&lt;Array.&lt;ProcessInfo&gt;&gt;</code></dt>
-<dd></dd>
 <dt><a href="#getRuntimeProcessList">getRuntimeProcessList()</a> ⇒ <code>Promise.&lt;Array.&lt;RuntimeProcessInfo&gt;&gt;</code></dt>
 <dd></dd>
 <dt><a href="#getDaemonStatus">getDaemonStatus()</a> ⇒ <code><a href="#DaemonStatus">Promise.&lt;DaemonStatus&gt;</a></code></dt>
@@ -90,10 +87,6 @@ If Jand sends back an error a `JandIpcError` will be thrown.
 ## connect()
 Connect to the JanD IPC socket
 
-**Kind**: global function
-<a name="getProcessList"></a>
-
-## getProcessList() ⇒ <code>Promise.&lt;Array.&lt;ProcessInfo&gt;&gt;</code>
 **Kind**: global function
 <a name="getRuntimeProcessList"></a>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ async function run() {
     console.log(await jand.getRuntimeProcessList())
     await jand.newProcess({
         Name: 'sus',
-        WorkingDirectory: 'i'
+        WorkingDirectory: '/',
+        Arguments: [],
+        Filename: "",
     }).catch(e => {
         console.log(e) // JandIpcError: ERR Something something
     })

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 export function connect(): Promise<void>;
-export function getProcessList(): Promise<ProcessInfo[]>;
 export function getRuntimeProcessList(): Promise<RuntimeProcessInfo[]>;
 export function getDaemonStatus(): Promise<DaemonStatus>;
 export function renameProcess(oldname: string, newname: string): Promise<void>;

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports.JandIpcError = JandIpcError
     socket.write(
         JSON.stringify({
             Type: type,
-            Data: data
+            Data: (typeof data === 'string' ? data : JSON.stringify(data))
         })
     )
 }
@@ -246,8 +246,8 @@ module.exports.restartProcess = async function(process) {
  */
 module.exports.newProcess = async function(process) {
     sendData('new-process', process)
-    const res = await expectResponse(/done|ERR:.+/)
-    if(res == 'done') return
+    const res = await expectResponse(/added|ERR:.+/)
+    if(res == 'added') return
 }
 
 module.exports.saveConfig = async function() {

--- a/index.js
+++ b/index.js
@@ -73,11 +73,12 @@ module.exports.JandIpcError = JandIpcError
  * @param {string | object | boolean | number} [data]
  */
  function sendData(type, data) {
-    if(DEBUG) console.log(`Sent ${type} ${data}`)
+    let dataSerialized = (typeof data === 'string' ? data : JSON.stringify(data))
+    if(DEBUG) console.log(`Sent ${type} ${dataSerialized}`)
     socket.write(
         JSON.stringify({
             Type: type,
-            Data: (typeof data === 'string' ? data : JSON.stringify(data))
+            Data: dataSerialized
         })
     )
 }

--- a/index.js
+++ b/index.js
@@ -130,14 +130,6 @@ module.exports.connect = async function () {
 }
 
 /**
- * @returns {Promise<ProcessInfo[]>}
- */
-module.exports.getProcessList = async function () {
-    sendData('get-process-list')
-    return await expectResponse(['Name', 'Enabled'], true)
-}
-
-/**
  * @returns {Promise<RuntimeProcessInfo[]>}
  */
 module.exports.getRuntimeProcessList = async function () {


### PR DESCRIPTION
Fixes serialization of packet's `Data` property.
Also includes edit to readme so it doesn't make the daemon error on `get-processes`(Since `Arguments` would be null) and removes `getProcessList()` function since it is now deleted.